### PR TITLE
fix Xcode build by adding two missing includes

### DIFF
--- a/src/consport.c
+++ b/src/consport.c
@@ -33,6 +33,7 @@
 #include <termios.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/select.h>
 #include <xhyve/support/misc.h>

--- a/src/pci_virtio_net_tap.c
+++ b/src/pci_virtio_net_tap.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <assert.h>
+#include <sys/time.h>
 #include <sys/select.h>
 #include <sys/param.h>
 #include <sys/uio.h>


### PR DESCRIPTION
I'm not sure why Xcode requires these, whereas the Makefile build does
not, but adding them fixes it, and with it the MacPorts port.